### PR TITLE
Fix absolute paths in report directory

### DIFF
--- a/src/main/java/org/sonar/plugins/pitest/PitestSensor.java
+++ b/src/main/java/org/sonar/plugins/pitest/PitestSensor.java
@@ -81,8 +81,12 @@ public class PitestSensor implements Sensor {
   public void analyse(Project project, SensorContext context) {
     java.io.File projectDirectory = fileSystem.baseDir();
     String reportDirectoryPath = settings.getString(REPORT_DIRECTORY_KEY);
-
-    java.io.File reportDirectory = new java.io.File(projectDirectory, reportDirectoryPath);
+    java.io.File reportDirectory = null;
+    if (reportDirectoryPath.startsWith("/")) {
+      reportDirectory = new java.io.File(reportDirectoryPath);
+    } else {
+      reportDirectory = new java.io.File(projectDirectory, reportDirectoryPath);
+    }
     java.io.File xmlReport = xmlReportFinder.findReport(reportDirectory);
     if (xmlReport == null) {
       LOG.warn("No XML PIT report found in directory {} !", reportDirectory);


### PR DESCRIPTION
Passing in absolute paths causes a lot of headaches trying to track down the source of the error. This fix will allow for relative or absolute pathing.